### PR TITLE
Resizing the album art to 128 x 128 pixels makes it display more smoothly

### DIFF
--- a/MiniSpotify/MiniSpotify/Source/MainWindow.xaml.cs
+++ b/MiniSpotify/MiniSpotify/Source/MainWindow.xaml.cs
@@ -201,6 +201,8 @@ namespace MiniSpotify
                     memory.Position = 0;
                     bmpImage.BeginInit();
                     bmpImage.StreamSource = memory;
+                    bmpImage.DecodePixelWidth = 128;
+                    bmpImage.DecodePixelHeight = 128;
                     bmpImage.CacheOption = BitmapCacheOption.OnLoad;
                     bmpImage.EndInit();
                 }


### PR DESCRIPTION
I simply had to specify a resolution of 128 x 128 pixels, which is the only power-of-two value higher than the currently displayed resolution of 75 x 75 pixels, to make the final downscaled image much smoother!

![Annotation 2019-11-22 133153](https://user-images.githubusercontent.com/5678332/69451096-98b5e100-0d2c-11ea-8bc4-d3cc19959b97.png)

Fixes #24 