### PR TITLE
Feature/#27 current playback context

### DIFF
--- a/MiniSpotify/MiniSpotify/MainWindow.xaml
+++ b/MiniSpotify/MiniSpotify/MainWindow.xaml
@@ -106,7 +106,8 @@
                     <ImageBrush ImageSource="Assets/Images/Icons/pause-icon.png" Stretch="Uniform"/>
                 </Button.Background>
             </Button>
-            <TextBlock Name="ArtistText" Margin="92,20,15,42" FontFamily="Lato Light" Foreground="White" FontSize="14"></TextBlock>
+            <TextBlock Name="ArtistText" Margin="92,20,15,56" FontFamily="Lato Light" Foreground="White" FontSize="14"></TextBlock>
+            <TextBlock Name="ContextText" Margin="92,36,15,40" FontFamily="Lato Light" Foreground="White" FontSize="12"></TextBlock>
             <!-- <Button x:Name="EditorButton" 
                 BorderBrush="Black" BorderThickness="0" 
                 Click="OnClickEditorButton" ClickMode="Press" HorizontalAlignment="Right" Width="5" Height="15" VerticalAlignment="Top" Margin="0,29,5,0" RenderTransformOrigin="0.5,0.5">

--- a/MiniSpotify/MiniSpotify/Source/APIRequestor.cs
+++ b/MiniSpotify/MiniSpotify/Source/APIRequestor.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
@@ -393,6 +394,48 @@ namespace MiniSpotify.API.Impl
             }
 
             return false;
+        }
+
+        public string GetPlaybackContext()
+        {
+            string InvalidReturn = string.Empty;
+
+            if (m_spotifyWebAPI != null)
+            {
+                Context context = m_spotifyWebAPI.GetPlayback().Context;
+
+                if (context == null)
+                {
+                    return InvalidReturn;
+                }
+                else
+                {
+                    if (string.IsNullOrWhiteSpace(context.Type))
+                    {
+                        return InvalidReturn;
+                    }
+                    else
+                    {
+                        string id = context.Uri.Split(':').Last();
+
+                        switch (context.Type)
+                        {
+                            case "album":
+                                return m_spotifyWebAPI.GetAlbum(id).Name;
+                            case "artist":
+                                return m_spotifyWebAPI.GetArtist(id).Name;
+                            case "playlist":
+                                return m_spotifyWebAPI.GetPlaylist(id).Name;
+                            default:
+                                return InvalidReturn;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                return InvalidReturn;
+            }
         }
 
         private async void PollSongChange()

--- a/MiniSpotify/MiniSpotify/Source/MainWindow.xaml.cs
+++ b/MiniSpotify/MiniSpotify/Source/MainWindow.xaml.cs
@@ -113,8 +113,9 @@ namespace MiniSpotify
 
             string trackName = a_latestTrackPlaying.Name;
             string artists = a_latestTrackPlaying.Artists[0].Name;
+            string context = APIRequestor.Instance.GetPlaybackContext();
 
-            for(int i = 1; i < a_latestTrackPlaying.Artists.Count; i++)
+            for (int i = 1; i < a_latestTrackPlaying.Artists.Count; i++)
             {
                 artists = string.Concat(artists, ", ", a_latestTrackPlaying.Artists[i].Name);
             }
@@ -124,6 +125,7 @@ namespace MiniSpotify
                 //Update any UI in this block.
                 TitleText.Text = a_latestTrackPlaying.Name;
                 ArtistText.Text = artists;
+                ContextText.Text = context;
             });
         }
 

--- a/MiniSpotify/MiniSpotify/Source/MainWindow.xaml.cs
+++ b/MiniSpotify/MiniSpotify/Source/MainWindow.xaml.cs
@@ -82,6 +82,7 @@ namespace MiniSpotify
             {
                 string trackName = a_latestTrack.Name;
                 string artists = a_latestTrack.Artists[0].Name;
+                string context = APIRequestor.Instance.GetPlaybackContext();
 
                 for (int i = 1; i < a_latestTrack.Artists.Count; i++)
                 {
@@ -93,6 +94,7 @@ namespace MiniSpotify
                     //Update any UI in this block.
                     TitleText.Text = a_latestTrack.Name;
                     ArtistText.Text = artists;
+                    ContextText.Text = context;
                 });
             }
         }


### PR DESCRIPTION
Hi there! Sorry for being a bit slower than before, I was busy with work and holidays.

I've made a first attempt at displaying the playback context (issue #27). This is how it looks like so far.

![Annotation 2019-12-28 215927](https://user-images.githubusercontent.com/5678332/71551819-086b5b80-29be-11ea-8889-065f3821ff33.png)

I've been working on a high DPI screen lately, and it looks fine on such a screen. It should be tested on a normal DPI screen as well.

However, an issue I've found with that solution so far is when you play from, say, your liked songs library. There's no context, and that means there's nothing under the artist field.

![Annotation 2019-12-28 220012](https://user-images.githubusercontent.com/5678332/71551831-48cad980-29be-11ea-8d01-d76a5c40d81c.png)

A solution would be to move the artist field automatically according to whether there's a context or not. Move it like before adding the context field if there's no context, for instance.

What do you think so far? Let's discuss about it. Thanks!